### PR TITLE
Tested and changed dependency on sequel to also support the version 5…

### DIFF
--- a/oui-offline.gemspec
+++ b/oui-offline.gemspec
@@ -26,7 +26,7 @@ Gem::Specification::new do |s|
   s.homepage = 'https://github.com/steakknife/oui'
   s.post_install_message = 'Oui!'
 
-  s.add_dependency 'sequel', '~> 4'
+  s.add_dependency 'sequel', ['>= 4', '< 6']
   if RUBY_PLATFORM == 'java'
     s.platform = 'java'
     s.add_dependency 'jdbc-sqlite3'

--- a/oui-offline.gemspec
+++ b/oui-offline.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification::new do |s|
   s.name = 'oui-offline'
-  s.version = '1.2.7'
+  s.version = '1.2.8'
   s.summary = 'Organizationally Unique Idenitfiers (OUI)'
   s.description = 'Organizationally Unique Idenitfiers (OUI) offline database'
   s.license = 'MIT'
@@ -26,15 +26,15 @@ Gem::Specification::new do |s|
   s.homepage = 'https://github.com/steakknife/oui'
   s.post_install_message = 'Oui!'
 
-  s.add_dependency 'sequel', ['>= 4', '< 6']
+  s.add_dependency 'sequel', '>= 4', '< 6'
   if RUBY_PLATFORM == 'java'
     s.platform = 'java'
-    s.add_dependency 'jdbc-sqlite3'
+    s.add_dependency 'jdbc-sqlite3', '~> 3.8'
   else
     s.platform = Gem::Platform::RUBY
-    s.add_dependency 'sqlite3', '~> 1'
+    s.add_dependency 'sqlite3', '~> 1.3'
   end
   s.add_development_dependency 'rake', '~> 10'
-  s.add_development_dependency 'minitest', '~> 5'
+  s.add_development_dependency 'minitest', '~> 5.0'
 end
 .tap {|gem| pk = File.expand_path(File.join('~/.keys', 'gem-private_key.pem')); gem.signing_key = pk if File.exist? pk; gem.cert_chain = ['gem-public_cert.pem']} # pressed firmly by waxseal


### PR DESCRIPTION
… releases.

Tested oui-offline with sequel-5.3.0 without any problems. Both lookup and update commands work as expected.

This will, among others, fix logstash-filter-oui which depends on oui-offline:
https://github.com/logstash-plugins/logstash-filter-oui/issues/8
https://github.com/logstash-plugins/logstash-filter-oui/issues/9

This will fix issue #22 